### PR TITLE
Adds per-transaction latencies, lets per-transaction latencies be set

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -42,16 +42,12 @@ extern int* failure2[];
 extern double max_rt[];
 extern double total_rt[];
 
+extern int rt_limit[];
+
 extern long clk_tck;
 extern sb_percentile_t local_percentile;
 
 #define MAX_RETRY 2000
-
-#define RTIME_NEWORD   5
-#define RTIME_PAYMENT  5
-#define RTIME_ORDSTAT  5
-#define RTIME_DELIVERY 80
-#define RTIME_SLEV     20
 
 int driver (int t_num)
 {
@@ -154,7 +150,7 @@ static int do_neword (int t_num)
 	sb_percentile_update(&local_percentile, rt);
 	hist_inc(0, rt);
 	if(counting_on){
-	  if( rt < RTIME_NEWORD ){
+	  if( rt < rt_limit[0]){
 	    success[0]++;
 	    success2[0][t_num]++;
 	  }else{
@@ -248,7 +244,7 @@ static int do_payment (int t_num)
 	total_rt[1] += rt;
 	hist_inc(1, rt);
 	if(counting_on){
-	  if( rt < RTIME_PAYMENT ){
+	  if( rt < rt_limit[1]){
 	    success[1]++;
 	    success2[1][t_num]++;
 	  }else{
@@ -321,7 +317,7 @@ static int do_ordstat (int t_num)
 	total_rt[2] += rt;
 	hist_inc(2, rt);
 	if(counting_on){
-	  if( rt < RTIME_ORDSTAT ){
+	  if( rt < rt_limit[2]){
 	    success[2]++;
 	    success2[2][t_num]++;
 	  }else{
@@ -387,7 +383,7 @@ static int do_delivery (int t_num)
 	total_rt[3] += rt;
 	hist_inc(3, rt );
 	if(counting_on){
-	  if( rt < RTIME_DELIVERY ){
+	  if( rt < rt_limit[3]){
 	    success[3]++;
 	    success2[3][t_num]++;
 	  }else{
@@ -454,7 +450,7 @@ static int do_slev (int t_num)
 	total_rt[4] += rt;
 	hist_inc(4, rt );
 	if(counting_on){
-	  if( rt < RTIME_SLEV ){
+	  if( rt < rt_limit[4]){
 	    success[4]++;
 	    success2[4][t_num]++;
 	  }else{

--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,20 @@ double cur_max_rt[5];
 
 double prev_total_rt[5];
 
+#define RTIME_NEWORD   5
+#define RTIME_PAYMENT  5
+#define RTIME_ORDSTAT  5
+#define RTIME_DELIVERY 80
+#define RTIME_SLEV     20
+
+int rt_limit[5] = {
+ RTIME_NEWORD,
+ RTIME_PAYMENT,
+ RTIME_ORDSTAT,
+ RTIME_DELIVERY,
+ RTIME_SLEV
+};
+
 sb_percentile_t local_percentile;
 
 int activate_transaction;
@@ -153,7 +167,7 @@ int main( int argc, char *argv[] )
 
   /* Parse args */
 
-    while ( (c = getopt(argc, argv, "h:P:d:u:p:w:c:r:l:i:f:t:m:o:S:")) != -1) {
+    while ( (c = getopt(argc, argv, "h:P:d:u:p:w:c:r:l:i:f:t:m:o:S:0:1:2:3:4:")) != -1) {
         switch (c) {
         case 'h':
             printf ("option h with value '%s'\n", optarg);
@@ -214,6 +228,26 @@ int main( int argc, char *argv[] )
         case 'S':
             printf ("option S (socket) with value '%s'\n", optarg);
             strncpy(db_socket, optarg, DB_STRING_MAX);
+            break;
+        case '0':
+            printf ("option 0 (response time limit for transaction 0) '%s'\n", optarg);
+            rt_limit[0] = atoi(optarg);
+            break;
+        case '1':
+            printf ("option 1 (response time limit for transaction 1) '%s'\n", optarg);
+            rt_limit[1] = atoi(optarg);
+            break;
+        case '2':
+            printf ("option 2 (response time limit for transaction 2) '%s'\n", optarg);
+            rt_limit[2] = atoi(optarg);
+            break;
+        case '3':
+            printf ("option 3 (response time limit for transaction 3) '%s'\n", optarg);
+            rt_limit[3] = atoi(optarg);
+            break;
+        case '4':
+            printf ("option 4 (response time limit for transaction 4) '%s'\n", optarg);
+            rt_limit[4] = atoi(optarg);
             break;
         case '?':
     	    printf("Usage: tpcc_start -h server_host -P port -d database_name -u mysql_user -p mysql_password -w warehouses -c connections -r warmup_time -l running_time -i report_interval -f report_file -t trx_file\n");
@@ -497,7 +531,9 @@ int main( int argc, char *argv[] )
 
   printf("\n<Raw Results>\n");
   for ( i=0; i<5; i++ ){
-    printf("  [%d] sc:%d  lt:%d  rt:%d  fl:%d \n", i, success[i], late[i], retry[i], failure[i]);
+    printf("  [%d] sc:%d lt:%d  rt:%d  fl:%d avg_rt: %.1f (%d)\n",
+           i, success[i], late[i], retry[i], failure[i],
+           total_rt[i] / (success[i] + late[i]), rt_limit[i]);
   }
   printf(" in %d sec.\n", (measure_time / PRINT_INTERVAL) * PRINT_INTERVAL);
 


### PR DESCRIPTION
Adds the options -0, -1, -2, -3 and -4 to set the max response time for determining
whether each transaction type is late. The defaults are used when not set.

Displays the average latency per transaction type at test end.

Output at test end where avg_rt: displays the average response time and the value at which a response is late in parentheses

<Raw Results>
  [0] sc:3129 lt:17179  rt:0  fl:0 avg_rt: 8.2 (5)
  [1] sc:20224 lt:85  rt:0  fl:0 avg_rt: 1.8 (5)
  [2] sc:2029 lt:2  rt:0  fl:0 avg_rt: 1.0 (5)
  [3] sc:2032 lt:0  rt:0  fl:0 avg_rt: 18.9 (80)
  [4] sc:63 lt:1968  rt:0  fl:0 avg_rt: 32.7 (20)
 in 300 sec.
