### PR TITLE
Add Dockerfile for easy packaging of the tpcc-mysql programs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y gcc libc6-dev zlib1g-dev make libmysqlclient-dev
+
+ADD . /tpcc-mysql
+ENV PATH /tpcc-mysql:$PATH
+WORKDIR /tpcc-mysql
+RUN cd src && make


### PR DESCRIPTION
The command to build a Docker container is:

`docker build -t tpcc-mysql ./`

... with working directory as the root of this repository. I published https://hub.docker.com/r/elreyes/tpcc-mysql/ but maybe you guys can publish your own official image if you think that's valuable.