### PR TITLE
Fix  connection_string size in the load.c is differnet with main function

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -42,7 +42,7 @@ int             i;
 int             option_debug = 0;	/* 1 if generating debug output    */
 int             is_local = 1;           /* "1" mean local */
 
-#define DB_STRING_MAX 51
+#define DB_STRING_MAX 128
 
 #include "parse_port.h"
 


### PR DESCRIPTION
In mian.c  define DB_STRING_MAX 128, but load.c  define DB_STRING_MAX  51,  when  db connection_string is larger than 51 and small than 128 will produce error.